### PR TITLE
daemon,snapshotstate: tweaks for snapshot import 

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -106,6 +106,7 @@ var api = []*Command{
 	debugPprofCmd,
 	debugCmd,
 	snapshotCmd,
+	snapshotImportCmd,
 	connectionsCmd,
 	modelCmd,
 	cohortsCmd,

--- a/daemon/api_snapshots.go
+++ b/daemon/api_snapshots.go
@@ -146,11 +146,12 @@ var snapshotImportCmd = &Command{
 func postSnapshotImport(c *Command, r *http.Request, user *auth.UserState) Response {
 	// XXX: check that we have enough space to import the compressed snapshots
 
-	// XXX: allocate a snapshot ID
-	setID := uint64(99)
-
+	// XXX: is this the right layer?
 	defer r.Body.Close()
-	if err := snapshotImport(context.TODO(), setID, r.Body); err != nil {
+
+	st := c.d.overlord.State()
+	setID, err := snapshotImport(context.TODO(), st, r.Body)
+	if err != nil {
 		return BadRequest(err.Error())
 	}
 

--- a/overlord/snapshotstate/snapshotstate.go
+++ b/overlord/snapshotstate/snapshotstate.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
@@ -257,7 +258,18 @@ func checkSnapshotTaskConflict(st *state.State, setID uint64, conflictingKinds .
 var List = backend.List
 
 // Import a given snapshot ID from an exported snapshot
-var Import = backend.Import
+func Import(ctx context.Context, st *state.State, r io.Reader) (uint64, error) {
+	st.Lock()
+	setID, err := newSnapshotSetID(st)
+	st.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	if err := backend.Import(ctx, setID, r); err != nil {
+		return 0, err
+	}
+	return setID, nil
+}
 
 // Save creates a taskset for taking snapshots of snaps' data.
 // Note that the state must be locked by the caller.


### PR DESCRIPTION
This PR tweaks the way the setID is calculated and also fixes a missing API addition that will make unit tests pass.